### PR TITLE
Fix: Ensure correct data type for price calculation using ceil() func

### DIFF
--- a/src/market_sell.php
+++ b/src/market_sell.php
@@ -191,7 +191,7 @@ switch ($_GET['act']) {
 			}
 
 			$price = stripslashes($_POST['price']);
-			$price = ceil($price);
+			$price = ceil((float)$price);
 
 			$fee = ceil($price / 100);
 			$fee = ceil($fee * 5);
@@ -284,7 +284,7 @@ switch ($_GET['act']) {
 			}
 
 			$price = stripslashes($_POST['price']);
-			$price = ceil($price);
+			$price = ceil((float)$price);
 
 			$fee = ceil($price / 100);
 			$fee = ceil($fee * 5);


### PR DESCRIPTION
Converted `$price` to float before applying `ceil()` function to prevent type mismatch errors. The line `$price = ceil($price);` was updated to `$price = ceil((float)$price);` to ensure the calculation executes correctly without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved price calculation by ensuring values are explicitly cast to float before rounding, enhancing type safety.

- **Chores**
	- No new functionality introduced; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->