### PR TITLE
Fix: prevent array offset access on non-array variables in battle.php

### DIFF
--- a/src/battle.php
+++ b/src/battle.php
@@ -37,7 +37,7 @@ switch ($_GET['act']) {
 				$enemy->$key = $value;
 			}
 		} else {
-			// Trate o caso em que não há dados para `$enemy1`
+			// Handle the case where there is no data for `$enemy1`
 			echo "Enemy data not found.";
 		}
 

--- a/src/battle.php
+++ b/src/battle.php
@@ -39,6 +39,8 @@ switch ($_GET['act']) {
 		} else {
 			// Handle the case where there is no data for `$enemy1`
 			echo "Enemy data not found.";
+			include_once(__DIR__ . "/templates/private_footer.php");
+			break;
 		}
 
 

--- a/src/battle.php
+++ b/src/battle.php
@@ -29,10 +29,18 @@ switch ($_GET['act']) {
 			break;
 		}
 
-		$enemy1 = $query->fetchrow(); //Get player info
-		foreach ($enemy1 as $key => $value) {
-			$enemy->$key = $value;
+		$enemy1 = $query->fetchrow();
+
+		if ($enemy1) {
+			$enemy = new stdClass();
+			foreach ($enemy1 as $key => $value) {
+				$enemy->$key = $value;
+			}
+		} else {
+			// Trate o caso em que não há dados para `$enemy1`
+			echo "Enemy data not found.";
 		}
+
 
 		if ($enemy->serv != $player->serv) {
 			include(__DIR__ . "/templates/private_header.php");


### PR DESCRIPTION
- Added checks to ensure variables are arrays before accessing their offsets in lines 498-503. This prevents warnings when the variables are integers or other non-array types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced battle logic to prevent errors when enemy data is missing.
	- Improved error messages for various scenarios during battle actions.

- **Bug Fixes**
	- Streamlined attack handling to ensure valid enemy data is checked before actions are taken.

These updates significantly improve the robustness and user experience during battles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->