### PR TITLE
fix: equipit blank page when level is not sufficient to equip

### DIFF
--- a/src/equipit.php
+++ b/src/equipit.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+define('PAGENAME', 'Equipment');
+
 include(__DIR__ . "/lib.php");
 $player = check_user($db);
 


### PR DESCRIPTION
Fixes issue where trying to equip an item with insufficient level redirects to a blank page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for the Equipment page.
	- Enhanced item attribute handling based on specific item IDs.

- **Improvements**
	- Streamlined logic for equipping and unequipping items, ensuring proper adjustments to player health and mana.
	- Improved checks for player vocation and item type eligibility.

- **Bug Fixes**
	- Refined item status handling for equipped and unequipped states, ensuring accurate database updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->